### PR TITLE
Setting up scaling for back servers

### DIFF
--- a/chart/workadventure-k8s/templates/back-service.yaml
+++ b/chart/workadventure-k8s/templates/back-service.yaml
@@ -1,14 +1,17 @@
+{{- range $replica, $f := until (int $.Values.back.replicaCount) }}
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "workadventure.fullname" . }}-back
+  name: {{ include "workadventure.fullname" $ }}-back-{{ $replica }}
   labels:
-    {{- include "workadventure.labels" . | nindent 4 }}
+    {{- include "workadventure.labels" $ | nindent 4 }}
     role: back
+    statefulset.kubernetes.io/pod-name: {{ include "workadventure.fullname" $ }}-back-{{ $replica }}
 spec:
-  type: {{ .Values.back.service.type }}
+  type: {{ $.Values.back.service.type }}
   ports:
-    - port: {{ .Values.back.service.port }}
+    - port: {{ $.Values.back.service.port }}
       targetPort: http
       protocol: TCP
       name: http
@@ -17,5 +20,7 @@ spec:
       protocol: TCP
       name: grpc
   selector:
-    {{- include "workadventure.selectorLabels" . | nindent 4 }}
+    {{- include "workadventure.selectorLabels" $ | nindent 4 }}
     role: back
+    statefulset.kubernetes.io/pod-name: {{ include "workadventure.fullname" $ }}-back-{{ $replica }}
+{{ end -}}

--- a/chart/workadventure-k8s/templates/back-statefulset.yaml
+++ b/chart/workadventure-k8s/templates/back-statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "workadventure.fullname" . }}-back
   labels:
@@ -9,16 +9,24 @@ spec:
   {{- if not .Values.back.autoscaling.enabled }}
   replicas: {{ .Values.back.replicaCount }}
   {{- end }}
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+    # Back servers are independent, so we can update all at once
+    # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#maximum-unavailable-pods
+    maxUnavailable: "100%"
   selector:
     matchLabels:
       {{- include "workadventure.selectorLabels" . | nindent 6 }}
       role: back
   template:
     metadata:
-      {{- with .Values.back.podAnnotations }}
       annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/back-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/back-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.back.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: back

--- a/chart/workadventure-k8s/templates/chat-deployment.yaml
+++ b/chart/workadventure-k8s/templates/chat-deployment.yaml
@@ -15,10 +15,12 @@ spec:
       role: chat
   template:
     metadata:
-      {{- with .Values.chat.podAnnotations }}
       annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/chat-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/chat-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.chat.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: chat

--- a/chart/workadventure-k8s/templates/ejabberd-deployment.yaml
+++ b/chart/workadventure-k8s/templates/ejabberd-deployment.yaml
@@ -15,10 +15,12 @@ spec:
       role: ejabberd
   template:
     metadata:
-      {{- with .Values.ejabberd.podAnnotations }}
       annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/ejabberd-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/ejabberd-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.ejabberd.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: ejabberd

--- a/chart/workadventure-k8s/templates/mapstorage-deployment.yaml
+++ b/chart/workadventure-k8s/templates/mapstorage-deployment.yaml
@@ -15,10 +15,12 @@ spec:
       role: mapstorage
   template:
     metadata:
-      {{- with .Values.mapstorage.podAnnotations }}
       annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/mapstorage-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/mapstorage-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.mapstorage.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: mapstorage

--- a/chart/workadventure-k8s/templates/play-deployment.yaml
+++ b/chart/workadventure-k8s/templates/play-deployment.yaml
@@ -15,10 +15,12 @@ spec:
       role: play
   template:
     metadata:
-      {{- with .Values.play.podAnnotations }}
       annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/play-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/play-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.play.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: play

--- a/chart/workadventure-k8s/templates/play-env.yaml
+++ b/chart/workadventure-k8s/templates/play-env.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "workadventure.labels" . | nindent 4 }}
 data:
-  API_URL: {{ include "workadventure.fullname" . }}-back:50051
+  API_URL: {{ range $replica, $f := until (int .Values.back.replicaCount) }}{{ include "workadventure.fullname" $ }}-back-{{ $replica }}:50051{{ if ne $replica (sub (int $.Values.back.replicaCount) 1)  }}{{ "," }}{{ end }}{{ end }}
   CHAT_URL: /chat/
   ICON_URL: /icon
   UPLOADER_URL: /uploader

--- a/chart/workadventure-k8s/templates/uploader-deployment.yaml
+++ b/chart/workadventure-k8s/templates/uploader-deployment.yaml
@@ -15,10 +15,12 @@ spec:
       role: uploader
   template:
     metadata:
-      {{- with .Values.uploader.podAnnotations }}
       annotations:
+        checksum/config: {{ (include (print $.Template.BasePath "/uploader-env.yaml") .) | sha256sum }}
+        checksum/secret: {{ (include (print $.Template.BasePath "/uploader-secret-env.yaml") .) | sha256sum }}
+        {{- with .Values.uploader.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "workadventure.selectorLabels" . | nindent 8 }}
         role: uploader


### PR DESCRIPTION
There can be many back servers but each back server must have its own service.
We are turning back-deployment into a back-statefulset and
generating one service for each pod.
Then we reference those services properly in the play containers.

Another change: Adding checksums to all deployments so that pods get redeployed when a config or secret changes